### PR TITLE
fix:HubNetwork 빈 생성 Lazy

### DIFF
--- a/src/main/java/com/jumunhasyeotjo/order_to_shipping/shipping/infrastructure/config/HubNetworkConfig.java
+++ b/src/main/java/com/jumunhasyeotjo/order_to_shipping/shipping/infrastructure/config/HubNetworkConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import com.jumunhasyeotjo.order_to_shipping.shipping.application.dto.Route;
 import com.jumunhasyeotjo.order_to_shipping.shipping.application.service.HubClient;
@@ -12,16 +13,24 @@ import com.jumunhasyeotjo.order_to_shipping.shipping.application.service.route.H
 import com.jumunhasyeotjo.order_to_shipping.shipping.application.service.route.RouteBasedHubNetwork;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 class HubNetworkConfig {
 
     private final HubClient hubClient;
 
     @Bean
+    @Lazy
     HubNetwork hubNetwork() {
-        List<Route> routes = hubClient.getRoutes();
-        return new RouteBasedHubNetwork(routes);
+        try {
+            List<Route> routes = hubClient.getRoutes();
+            return new RouteBasedHubNetwork(routes);
+        } catch (Exception e) {
+            log.warn("Failed to load hub routes from HubClient. Falling back to empty hub network.", e);
+            return new RouteBasedHubNetwork(Collections.emptyList());
+        }
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #63 

## 📋 구현 기능 명세
- [x] fix: 	HubNetwork 빈 생성 Lazy

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
1.	@Lazy 추가
	•	HubNetwork 빈이 컨텍스트 올라갈 때 바로 생성되지 않고,
실제로 필요한 시점까지 생성을 미룬다.
	•	contextLoads()처럼 단순 컨텍스트 로딩 테스트에서는
HubNetwork를 안 쓰면 Feign 호출도 안 나감 → UnknownHostException 방지
